### PR TITLE
Updating content and links for 2025 June logistics page

### DIFF
--- a/workshop/local-participant-information.md
+++ b/workshop/local-participant-information.md
@@ -30,7 +30,7 @@ If you have trouble finding the building or the room on the first day of trainin
 
 * SEPTA is the public transportation system in Philadelphia and the surrounding area.
 * You can use cash or contactless pay (credit/debit card or Apple/Google/Samsung Pay) on SEPTA subways and buses.
-* Please refer to the [SEPTA website](https://www5.septa.org/travel/) for more information. (**Note:** The [SEPTA trip planner](https://beta-plan.septa.org/#/) may be a helpful tool if you plan to travel around the city during your stay.)
+* Please refer to the [SEPTA website](https://www5.septa.org/travel/) for more information. (**Note:** The [SEPTA trip planner](https://plan.septa.org/#/) may be a helpful tool if you plan to travel around the city during your stay.)
 
 **Other**
 
@@ -56,6 +56,7 @@ We will evaluate such requests on a case-by-case basis.
 
 To qualify for reimbursement:
 
+* You must be a childhood cancer researcher.
 * You will need to have included this request in your application.
 * You will be required to provide documentation of travel expenses, such as transportation and lodging receipts, and to fill out a reimbursement form after the workshop ends.
 * You must attend the entirety of the workshop.
@@ -63,8 +64,5 @@ To qualify for reimbursement:
 ## Health and Safety
 
 Alex's Lemonade Stand Foundation's Childhood Cancer Data Lab will comply with any governmental requirements related to health and safety.
-We encourage workshop participants to adhere to US governmental guidance.
-You may wish to review the [CDC COVID-19 by County guidance](https://www.cdc.gov/coronavirus/2019-ncov/your-health/covid-by-county.html) when planning for workshop attendance.
-
 If you are feeling sick, please do not attend the workshop.
 We will not withhold your deposit if you cannot attend because you are sick.


### PR DESCRIPTION
This PR addresses #8. 

Most of the content is fine! I updated a SEPTA link that was no longer working. I added a requirement under travel reimbursement. I removed the COVID-specific information under health and safety. The government website is no longer being updated. 