### PR TITLE
Add slot for OpenScPCA presentation

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -83,6 +83,7 @@ Monterey
 Muris
 musculus
 nonconsensual
+OpenScPCA
 OSCA
 PHI
 PII

--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -52,6 +52,7 @@ The planned schedule for the June 10-12, 2025 Data Lab Training Workshop appears
 |           | [Exercise: AUCell](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq-advanced/exercise_04-scrna_pathway.Rmd)
 |           | [Exercise: Evaluating cluster quality](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq-advanced/exercise_05-cluster_evaluation.Rmd)
 |           | [Resources for consultation sessions](./workshop-resources.md)
+| 2:45 PM   | An Introduction to the OpenScPCA Project
 | 3:00 PM   | Participant Presentations!
 | 4:00 PM   | *Adjourn*
 


### PR DESCRIPTION
Closes #9 

This PR finalizes the schedule. I confirmed all links are working, so there are no additional changes I had to make there 🎉 The only thing I had to update to wrap up the schedule was a slot for the OpenScPCA talk at 2:45 as we have indicated on the internal schedule: https://github.com/AlexsLemonade/training-admin/blob/master/internal-schedules/2025-june-internal-schedule.md#thursday-2025-06-12